### PR TITLE
カメラの設定と生成したキャラの設定をそれぞれ自動セットする機能を追加。

### DIFF
--- a/Assets/Datas/SkinDataSO.asset
+++ b/Assets/Datas/SkinDataSO.asset
@@ -15,3 +15,5 @@ MonoBehaviour:
   skinDataList:
   - id: 0
     charaPrefab: {fileID: 281138400, guid: e8c8754945983b84c9b2498736fb4109, type: 3}
+  - id: 1
+    charaPrefab: {fileID: 281138400, guid: e8c8754945983b84c9b2498736fb4109, type: 3}

--- a/Assets/Polytope Studio/Lowpoly Medieval Demos/Environment_Free/Environment_Free.unity
+++ b/Assets/Polytope Studio/Lowpoly Medieval Demos/Environment_Free/Environment_Free.unity
@@ -2818,6 +2818,7 @@ MonoBehaviour:
   generateGemCount: 20
   playerChara: {fileID: 0}
   startTran: {fileID: 1615368604}
+  cameraController: {fileID: 2101103845}
 --- !u!114 &1816170732
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CameraControllerFromCinemachine.cs
+++ b/Assets/Scripts/CameraControllerFromCinemachine.cs
@@ -62,6 +62,10 @@ public class CameraControllerFromCinemachine : MonoBehaviour
     /// <param name="target"></param>
     public void SetTarget(GameObject target) {
         targetObj = target;
-        GetComponent<CinemachineVirtualCamera>().Follow = targetObj.transform;
+
+        if (TryGetComponent(out CinemachineVirtualCamera camera)) {
+            camera.Follow = targetObj.transform;    
+        }
+        //GetComponent<CinemachineVirtualCamera>().Follow = targetObj.transform;
     }
 }

--- a/Assets/Scripts/CameraControllerFromCinemachine.cs
+++ b/Assets/Scripts/CameraControllerFromCinemachine.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using Cinemachine;
 using UnityEngine;
 
 public class CameraControllerFromCinemachine : MonoBehaviour
@@ -53,5 +54,14 @@ public class CameraControllerFromCinemachine : MonoBehaviour
 
         // ƒJƒƒ‰‚Ì‰ñ“]
         transform.localEulerAngles = localAngle;
+    }
+
+    /// <summary>
+    /// ’ÇÕ‘ÎÛ‚ğİ’è
+    /// </summary>
+    /// <param name="target"></param>
+    public void SetTarget(GameObject target) {
+        targetObj = target;
+        GetComponent<CinemachineVirtualCamera>().Follow = targetObj.transform;
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -18,6 +18,9 @@ public class GameManager : MonoBehaviour
     
     [SerializeField] 
     private Transform startTran;
+
+    [SerializeField] 
+    private CameraControllerFromCinemachine cameraController;
     
     private EnemyGenerator enemyGenerator;
     private GemGenerator gemGenerator;
@@ -41,6 +44,10 @@ public class GameManager : MonoBehaviour
         UserData.instance.SetCurrentCharaData();
         playerChara = Instantiate(DataBaseManager.instance.GetSkinData(UserData.instance.currentCharaData.id),
             startTran.position, Quaternion.identity);
+        
+        playerChara.SetUpPlayer(cameraController);
+        
+        cameraController.SetTarget(playerChara.gameObject);
     }
 
     /// <summary>

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -28,7 +28,11 @@ public class PlayerController : MonoBehaviour
     private Vignette vignette;
 
 
-    void Start() {
+
+    public void SetUpPlayer(CameraControllerFromCinemachine camera) {
+
+        postProcessing = camera.GetComponent<CinemachinePostProcessing>();
+
         TryGetComponent(out rb);
         //TryGetComponent(out anim);
 
@@ -43,8 +47,26 @@ public class PlayerController : MonoBehaviour
 
         moveSpeed = UserData.instance != null ? UserData.instance.currentCharaData.moveSpeed : ConstData.DEFAULT_MOVE_SPEED;
     }
+    
+    // void Start() {
+    //     TryGetComponent(out rb);
+    //     //TryGetComponent(out anim);
+    //
+    //     TryGetComponent(out playerAnim);
+    //
+    //     // 通常の取得方法
+    //     //vignette = postProcessing.m_Profile.GetSetting<Vignette>();
+    //
+    //     if (!postProcessing.m_Profile.TryGetSettings(out vignette)) {
+    //         Debug.Log("Vignette 取得出来ません。");
+    //     } 
+    //
+    //     moveSpeed = UserData.instance != null ? UserData.instance.currentCharaData.moveSpeed : ConstData.DEFAULT_MOVE_SPEED;
+    // }
 
     void Update() {
+        
+        if(!playerAnim) return;
 
         // Attack タグの設定されているアニメ再生中の場合
         if (playerAnim.GetAnimator().GetCurrentAnimatorStateInfo(0).IsTag("Attack")) {
@@ -72,6 +94,8 @@ public class PlayerController : MonoBehaviour
 
     void FixedUpdate() {
 
+        if (!rb) return;
+        
         // 向きを考慮しない移動方法。移動方向にスピードを掛ける。ジャンプや落下がある場合は、別途Y軸方向の速度ベクトルを足す。
         //rb.velocity = new (inputHorizontal * moveSpeed, rb.velocity.y, inputVertical * moveSpeed);
 

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -28,10 +28,14 @@ public class PlayerController : MonoBehaviour
     private Vignette vignette;
 
 
-
+    /// <summary>
+    /// èâä˙ê›íË
+    /// </summary>
+    /// <param name="camera"></param>
     public void SetUpPlayer(CameraControllerFromCinemachine camera) {
 
-        postProcessing = camera.GetComponent<CinemachinePostProcessing>();
+        camera.TryGetComponent(out postProcessing);
+        //postProcessing = camera.GetComponent<CinemachinePostProcessing>();
 
         TryGetComponent(out rb);
         //TryGetComponent(out anim);

--- a/Assets/UnityChan/Animators/UnityChanLocomotions.controller
+++ b/Assets/UnityChan/Animators/UnityChanLocomotions.controller
@@ -326,6 +326,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &-2890718151263675470
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Rest
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 110233628}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.08571428
+  m_TransitionOffset: 0
+  m_ExitTime: 0.9
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!114 &-2837107784403821411
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -428,14 +453,14 @@ AnimatorController:
   m_Name: UnityChanLocomotions
   serializedVersion: 5
   m_AnimatorParameters:
-  - m_Name: Speed
+  - m_Name: Direction
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
-  - m_Name: Direction
-    m_Type: 1
+  - m_Name: Jump
+    m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
@@ -464,8 +489,8 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
-  - m_Name: Jump
-    m_Type: 9
+  - m_Name: Speed
+    m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
@@ -621,9 +646,9 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.08328929
+  m_TransitionDuration: 0.022278616
   m_TransitionOffset: 0
-  m_ExitTime: 0.0000000010376454
+  m_ExitTime: 0.0000000012706985
   m_HasExitTime: 0
   m_HasFixedDuration: 0
   m_InterruptionSource: 0
@@ -721,9 +746,9 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.23076922
+  m_TransitionDuration: 0.22
   m_TransitionOffset: 0
-  m_ExitTime: 0.9
+  m_ExitTime: 0.40090492
   m_HasExitTime: 1
   m_HasFixedDuration: 0
   m_InterruptionSource: 0
@@ -1219,7 +1244,7 @@ AnimatorState:
   m_IKOnFeet: 1
   m_WriteDefaultValues: 1
   m_Mirror: 0
-  m_SpeedParameterActive: 1
+  m_SpeedParameterActive: 0
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
@@ -1400,7 +1425,7 @@ AnimatorStateMachine:
     m_Position: {x: -610, y: -90, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 110233628}
-    m_Position: {x: -890, y: -200, z: 0}
+    m_Position: {x: -880, y: -200, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 110240722}
     m_Position: {x: -880, y: -90, z: 0}
@@ -1432,10 +1457,10 @@ AnimatorStateMachine:
     - {fileID: -6467338082314344282}
   m_StateMachineBehaviours: []
   m_AnyStatePosition: {x: -460, y: -340, z: 0}
-  m_EntryPosition: {x: -610, y: 40, z: 0}
+  m_EntryPosition: {x: -590, y: -290, z: 0}
   m_ExitPosition: {x: 30, y: -340, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: 110200000}
+  m_DefaultState: {fileID: 110274123}
 --- !u!1107 &110786135
 AnimatorStateMachine:
   serializedVersion: 6
@@ -1540,6 +1565,31 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 82d0fd06a27c3dc4ca528658a064f249, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1101 &1428881576029234060
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Attack
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 2866442220538132997}
+  m_Solo: 0
+  m_Mute: 1
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.26354074
+  m_TransitionOffset: 0
+  m_ExitTime: 3.5923674e-11
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &2038943665251788584
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -1579,9 +1629,9 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.21037534
+  m_TransitionDuration: 0.121742375
   m_TransitionOffset: 0
-  m_ExitTime: 8.2781154e-10
+  m_ExitTime: 0.0000000011076058
   m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
@@ -1616,6 +1666,56 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &3297747549714988905
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 4
+    m_ConditionEvent: Speed
+    m_EventTreshold: -0.1
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 110240722}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.08571428
+  m_TransitionOffset: 0
+  m_ExitTime: 0.9
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &3554551751791230171
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 3
+    m_ConditionEvent: Speed
+    m_EventTreshold: 0.1
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 110274123}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.022278616
+  m_TransitionOffset: 0
+  m_ExitTime: 0.0000000012706985
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &4548407635683822301
 AnimatorState:
   serializedVersion: 6
@@ -1681,6 +1781,31 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 82d0fd06a27c3dc4ca528658a064f249, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1101 &6068511579742201337
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Attack
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: -3664100605133285386}
+  m_DstState: {fileID: 0}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.24376732
+  m_TransitionOffset: 0
+  m_ExitTime: 4.723934e-10
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &6465058127844195048
 AnimatorStateTransition:
   m_ObjectHideFlags: 1

--- a/UserSettings/Layouts/default-2021.dwlt
+++ b/UserSettings/Layouts/default-2021.dwlt
@@ -19,7 +19,7 @@ MonoBehaviour:
     width: 2560
     height: 1357.3334
   m_ShowMode: 4
-  m_Title: Hierarchy
+  m_Title: Scene
   m_RootView: {fileID: 3}
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
@@ -43,8 +43,8 @@ MonoBehaviour:
     y: 664.6667
     width: 456.66663
     height: 642.6667
-  m_MinSize: {x: 232, y: 271}
-  m_MaxSize: {x: 10002, y: 10021}
+  m_MinSize: {x: 230, y: 250}
+  m_MaxSize: {x: 10000, y: 10000}
   m_ActualView: {fileID: 23}
   m_Panes:
   - {fileID: 23}
@@ -146,7 +146,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 200}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 112
+  controlID: 221
 --- !u!114 &7
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -171,7 +171,7 @@ MonoBehaviour:
   m_MinSize: {x: 100, y: 200}
   m_MaxSize: {x: 8096, y: 16192}
   vertical: 1
-  controlID: 119
+  controlID: 172
 --- !u!114 &8
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -182,7 +182,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: AnimatorControllerTool
+  m_Name: SceneView
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
@@ -191,15 +191,15 @@ MonoBehaviour:
     y: 0
     width: 1375.3334
     height: 758
-  m_MinSize: {x: 101, y: 121}
+  m_MinSize: {x: 201, y: 221}
   m_MaxSize: {x: 4001, y: 4021}
-  m_ActualView: {fileID: 20}
+  m_ActualView: {fileID: 18}
   m_Panes:
   - {fileID: 18}
   - {fileID: 19}
   - {fileID: 20}
-  m_Selected: 2
-  m_LastSelected: 0
+  m_Selected: 0
+  m_LastSelected: 2
 --- !u!114 &9
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -219,8 +219,8 @@ MonoBehaviour:
     y: 758
     width: 1375.3334
     height: 549.3334
-  m_MinSize: {x: 201, y: 221}
-  m_MaxSize: {x: 4001, y: 4021}
+  m_MinSize: {x: 200, y: 200}
+  m_MaxSize: {x: 4000, y: 4000}
   m_ActualView: {fileID: 21}
   m_Panes:
   - {fileID: 21}
@@ -251,7 +251,7 @@ MonoBehaviour:
   m_MinSize: {x: 100, y: 200}
   m_MaxSize: {x: 8096, y: 16192}
   vertical: 1
-  controlID: 170
+  controlID: 143
 --- !u!114 &11
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -302,7 +302,7 @@ MonoBehaviour:
   m_MinSize: {x: 100, y: 200}
   m_MaxSize: {x: 8096, y: 16192}
   vertical: 1
-  controlID: 113
+  controlID: 222
 --- !u!114 &13
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -322,8 +322,8 @@ MonoBehaviour:
     y: 0
     width: 728
     height: 982.6667
-  m_MinSize: {x: 276, y: 71}
-  m_MaxSize: {x: 4001, y: 4021}
+  m_MinSize: {x: 275, y: 50}
+  m_MaxSize: {x: 4000, y: 4000}
   m_ActualView: {fileID: 17}
   m_Panes:
   - {fileID: 17}
@@ -416,7 +416,7 @@ MonoBehaviour:
     m_SaveData: []
   m_LockTracker:
     m_IsLocked: 0
-  m_LastSelectedObjectID: 23998
+  m_LastSelectedObjectID: -4796
 --- !u!114 &17
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -963,7 +963,7 @@ MonoBehaviour:
   m_ShowGizmos: 0
   m_TargetDisplay: 0
   m_ClearColor: {r: 0, g: 0, b: 0, a: 0}
-  m_TargetSize: {x: 381, y: 761.00006}
+  m_TargetSize: {x: 1015, y: 507.33337}
   m_TextureFilterMode: 0
   m_TextureHideFlags: 61
   m_RenderIMGUI: 1
@@ -978,10 +978,10 @@ MonoBehaviour:
     m_VRangeLocked: 0
     hZoomLockedByDefault: 0
     vZoomLockedByDefault: 0
-    m_HBaseRangeMin: -127
-    m_HBaseRangeMax: 127
-    m_VBaseRangeMin: -253.66669
-    m_VBaseRangeMax: 253.66669
+    m_HBaseRangeMin: -338.33334
+    m_HBaseRangeMax: 338.33334
+    m_VBaseRangeMin: -169.11113
+    m_VBaseRangeMax: 169.11113
     m_HAllowExceedBaseRangeMin: 1
     m_HAllowExceedBaseRangeMax: 1
     m_VAllowExceedBaseRangeMin: 1
@@ -1055,7 +1055,7 @@ MonoBehaviour:
       scrollPos: {x: 0, y: 0}
       m_SelectedIDs: 
       m_LastClickedID: 0
-      m_ExpandedIDs: fef9ffff04faffff08faffff0cfaffff76faffff7afaffff7efaffffaafaffffb0faffffecfaffff
+      m_ExpandedIDs: e8faffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -1121,22 +1121,22 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/UnityChan/Animators
+    - Assets/Datas
     m_Globs: []
     m_OriginalText: 
   m_ViewMode: 1
   m_StartGridSize: 16
   m_LastFolders:
-  - Assets/UnityChan/Animators
+  - Assets/Datas
   m_LastFoldersGridSize: 16
   m_LastProjectPath: C:\Users\komay\Documents\3D_TopView_Action
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
     scrollPos: {x: 0, y: 26.333313}
-    m_SelectedIDs: d0740000
-    m_LastClickedID: 29904
-    m_ExpandedIDs: 0000000056670000586700005a6700005c6700005e67000060670000626700006467000066670000686700006a6700006c6700006e67000070670000726700007467000076670000786700007a670000b067000000ca9a3bffffff7f
+    m_SelectedIDs: 10780000
+    m_LastClickedID: 30736
+    m_ExpandedIDs: 000000006467000066670000686700006a6700006c6700006e67000070670000726700007467000076670000786700007a6700007c6700007e6700008067000082670000846700008667000088670000c067000000ca9a3bffffff7f
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -1164,7 +1164,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 0000000056670000586700005a6700005c6700005e67000060670000626700006467000066670000686700006a6700006c6700006e67000070670000726700007467000076670000786700007a670000
+    m_ExpandedIDs: 000000006467000066670000686700006a6700006c6700006e67000070670000726700007467000076670000786700007a6700007c6700007e6700008067000082670000846700008667000088670000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 


### PR DESCRIPTION
・PlayerController.cs、CameraControllerFromCinemachine.cs、GameManager.cs を修正し、
　ゲーム実行時に生成されたキャラにカメラの情報を設定。同様に、カメラにも追跡対象としてキャラを設定。

・デバッグ。キャラを変えて確認。問題なし。リファクタリング。